### PR TITLE
Update rchain-style.css

### DIFF
--- a/rchain-style.css
+++ b/rchain-style.css
@@ -1,5 +1,5 @@
 #xf-logo {
-    background-image: url(https://developer.rchain.coop/logo-cropped.png);
+    background-image: url(https://raw.githubusercontent.com/rchain/rchain.tools/master/rchain.png);
     background-size: cover;
     width: 180px;
     height: 180px;


### PR DESCRIPTION
The logo on the older URL most likely was removed and so I changed the logo from one on github https://raw.githubusercontent.com/rchain/rchain.tools/master/rchain.png